### PR TITLE
Pod fixes

### DIFF
--- a/lib/Class/Meta.pm
+++ b/lib/Class/Meta.pm
@@ -888,7 +888,7 @@ a user interface. Optional.
 
 You can implicitly define the constructor in your class by passing a code
 reference via the C<code> parameter. Once C<build()> is called,
-L<Kinetic::Meta::Constructor|Kinetic::Meta::Constructor> will install the
+L<Class::Meta::Constructor|Class::Meta::Constructor> will install the
 constructor into the package for which the Class::Meta object was defined, and
 with the name specified via the C<name> parameter. Note that if the
 constructor view is PRIVATE or PROTECTED, the constructor will be wrapped in
@@ -1191,7 +1191,7 @@ Otherwise, it's up to the class implementation itself to do the job.
 
 You can implicitly define the method in your class by passing a code reference
 via the C<code> parameter. Once C<build()> is called,
-L<Kinetic::Meta::Method|Kinetic::Meta::Method> will install the method into
+L<Class::Meta::Method|Class::Meta::Method> will install the method into
 the package for which the Class::Meta object was defined, and with the name
 specified via the C<name> parameter. If the C<view> is anything other than
 PUBLIC, it will be enforced.

--- a/lib/Class/Meta.pm
+++ b/lib/Class/Meta.pm
@@ -11,6 +11,7 @@ Generate a class:
   package MyApp::Thingy;
   use strict;
   use Class::Meta;
+  use Data::UUID;
 
   BEGIN {
 
@@ -54,14 +55,13 @@ Generate a class:
       $cm->build;
   }
 
-  sub chck_pass { ... }
-
 Or use Class::Meta::Express for a more pleasant declarative syntax (highly
 recommended!):
 
   package MyApp::Thingy;
   use strict;
   use Class::Meta::Express;
+  use Data::UUID;
 
   class {
       meta thingy => ( default_type => 'string' );
@@ -80,8 +80,8 @@ Now isn't that nicer? Then use the class:
 
   use MyApp::Thingy;
 
-  my $thingy = MyApp::Thingy->new( id => 19 );
-  print "ID: ", $thingy->id, $/;
+  my $thingy = MyApp::Thingy->new;
+  print "UUID: ", $thingy->uuid, $/;
   $thingy->name('Larry');
   print "Name: ", $thingy->name, $/;
   $thingy->age(42);

--- a/t/pod-spelling.t
+++ b/t/pod-spelling.t
@@ -11,6 +11,7 @@ all_pod_files_spelling_ok();
 __DATA__
 affordance
 Affordance
+getter
 getters
 iThreads
 multi


### PR DESCRIPTION
I polished `Class::Meta`'s documentation, fixing code snippets (so that they're runnable after copy-pasting), a failing test (only spelling of 'getter') and changing two links to unaccessible `Kinetic` modules.
